### PR TITLE
remove deprecated property

### DIFF
--- a/ALRT/ALRT.swift
+++ b/ALRT/ALRT.swift
@@ -280,6 +280,9 @@ private extension UIViewController {
 
 private extension UIApplication {
     func topMostViewController() -> UIViewController? {
-        return self.keyWindow?.rootViewController?.topMostViewController()
+        guard let keyWindow = windows.last else {
+            return nil
+        }
+        return keyWindow.rootViewController?.topMostViewController()
     }
 }


### PR DESCRIPTION
thanks for creating a useful library. I found a deprecated property. 
if you have time, please check it out.

https://developer.apple.com/documentation/uikit/uiapplication/1622924-keywindow