### PR TITLE
Added default configuration

### DIFF
--- a/ALRT.podspec
+++ b/ALRT.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |s|
   s.name         = "ALRT"
-  s.version      = "1.3.4"
+  s.version      = "1.3.5"
   s.summary      = "An easier constructor for UIAlertController. Present from anywhere."
   s.homepage     = "https://github.com/mshrwtnb/ALRT"
   s.screenshots  = "https://raw.githubusercontent.com/wiki/mshrwtnb/ALRT/logobanner.png"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Masahiro Watanabe" => "iammshr@gmail.com" }
-  s.social_media_url   = "http://qiita.com/mshrwtnb"
+  s.social_media_url   = "https://mshrwtnb.com/"
   s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/mshrwtnb/ALRT.git", :tag => "#{s.version}" }
   s.source_files  = "ALRT/*.swift"

--- a/ALRT/ALRT.swift
+++ b/ALRT/ALRT.swift
@@ -4,6 +4,16 @@ import UIKit
 
 public class ALRT {
     /**
+     Configuration struct to define default tintColor for buttons, ok button title and cancel button title.
+     Use `defaultConfiguration`
+     */
+    public struct Configuration {
+        public var tintColor: UIColor?
+        public var okTitle: String?
+        public var cancelTitle: String?
+    }
+
+    /**
      Result indicating whether the alert is displayed or not.
 
      - success: The alert is displayed.
@@ -28,7 +38,9 @@ public class ALRT {
         case sourceViewControllerNil
     }
 
-    var alertController: UIAlertController?
+    public static var defaultConfiguration: Configuration?
+
+    public var alertController: UIAlertController?
 
     private init() {}
 
@@ -37,11 +49,17 @@ public class ALRT {
         message: String?,
         preferredStyle: UIAlertController.Style
     ) {
-        alertController = UIAlertController(
+        let alertController = UIAlertController(
             title: title,
             message: message,
             preferredStyle: preferredStyle
         )
+
+        if let tintColor = ALRT.defaultConfiguration?.tintColor {
+            alertController.view.tintColor = tintColor
+        }
+
+        self.alertController = alertController
     }
 
     // MARK: Creating an ALRT
@@ -154,7 +172,7 @@ public class ALRT {
 
     @discardableResult
     public func addOK(
-        _ title: String = "OK",
+        _ title: String = ALRT.defaultConfiguration?.okTitle ?? "OK",
         style: UIAlertAction.Style = .default,
         preferred: Bool = false,
         handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil
@@ -175,7 +193,7 @@ public class ALRT {
 
     @discardableResult
     public func addCancel(
-        _ title: String = "Cancel",
+        _ title: String = ALRT.defaultConfiguration?.cancelTitle ?? "Cancel",
         style: UIAlertAction.Style = .cancel,
         preferred: Bool = false,
         handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil
@@ -234,7 +252,7 @@ public class ALRT {
         animated: Bool = true,
         completion: @escaping ((ALRT.Result) -> Void) = { _ in }
     ) {
-        guard let alert = self.alertController else {
+        guard let alert = alertController else {
             completion(.failure(.alertControllerNil))
             return
         }
@@ -255,12 +273,16 @@ public class ALRT {
             return viewController
         }()
 
-        if let sourceViewController = sourceViewController {
-            sourceViewController.present(alert, animated: animated) {
-                completion(.success)
-            }
-        } else {
+        guard let source = sourceViewController else {
             completion(.failure(.sourceViewControllerNil))
+            return
+        }
+
+        source.present(alert, animated: animated) {
+            if let tintColor = ALRT.defaultConfiguration?.tintColor {
+                alert.view.tintColor = tintColor
+            }
+            completion(.success)
         }
     }
 }

--- a/ALRT/ALRT.swift
+++ b/ALRT/ALRT.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Responsible for creating and managing an ALRT object.
 
-open class ALRT {
+public class ALRT {
     
     /**
      Result indicating whether the alert is displayed or not.
@@ -51,7 +51,7 @@ open class ALRT {
      - returns: ALRT
      */
     
-    open class func create(_ style: UIAlertController.Style,
+    public class func create(_ style: UIAlertController.Style,
                            title: String? = nil,
                            message: String? = nil) -> ALRT {
         
@@ -69,7 +69,7 @@ open class ALRT {
      */
     
     @discardableResult
-    open func fetch(_ handler: ((_ alertController: UIAlertController?) -> Void)) -> Self {
+    public func fetch(_ handler: ((_ alertController: UIAlertController?) -> Void)) -> Self {
         handler(self.alert)
         return self
     }
@@ -85,7 +85,7 @@ open class ALRT {
      */
     
     @discardableResult
-    open func addTextField(_ configurationHandler: ((_ textField: UITextField) -> Void)?) -> Self {
+    public func addTextField(_ configurationHandler: ((_ textField: UITextField) -> Void)?) -> Self {
         guard alert?.preferredStyle == .alert else {
             return self
         }
@@ -114,7 +114,7 @@ open class ALRT {
      */
     
     @discardableResult
-    open func addAction(_ title: String?,
+    public func addAction(_ title: String?,
                         style: UIAlertAction.Style = .default,
                         preferred: Bool = false,
                         handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil) -> Self {
@@ -147,7 +147,7 @@ open class ALRT {
      */
     
     @discardableResult
-    open func addOK(_ title: String = "OK",
+    public func addOK(_ title: String = "OK",
                     style: UIAlertAction.Style = .default,
                     preferred: Bool = false,
                     handler:((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil) -> Self {
@@ -167,7 +167,7 @@ open class ALRT {
      */
     
     @discardableResult
-    open func addCancel(_ title: String = "Cancel",
+    public func addCancel(_ title: String = "Cancel",
                         style: UIAlertAction.Style = .cancel,
                         preferred: Bool = false,
                         handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil) -> Self {
@@ -187,7 +187,7 @@ open class ALRT {
      */
     
     @discardableResult
-    open func addDestructive(_ title: String?,
+    public func addDestructive(_ title: String?,
                              style: UIAlertAction.Style = .destructive,
                              preferred: Bool = false,
                              handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil)-> Self {
@@ -206,7 +206,7 @@ open class ALRT {
      */
     
     @discardableResult
-    open func configurePopoverPresentation(_ configurationHandler:((_ popover: UIPopoverPresentationController?) -> Void)? = nil) -> Self {
+    public func configurePopoverPresentation(_ configurationHandler:((_ popover: UIPopoverPresentationController?) -> Void)? = nil) -> Self {
         
         configurationHandler?(alert?.popoverPresentationController)
         
@@ -223,7 +223,7 @@ open class ALRT {
      - parameter completion:     The block to execute after the presentation finishes. This block has no return value and takes an Result parameter. The default value is nil.
      */
     
-    open func show(_ viewControllerToPresent: UIViewController? = nil,
+    public func show(_ viewControllerToPresent: UIViewController? = nil,
                    animated: Bool = true,
                    completion: @escaping ((ALRT.Result) -> Void) = { _ in } ) {
         

--- a/ALRT/ALRT.swift
+++ b/ALRT/ALRT.swift
@@ -31,9 +31,9 @@ open class ALRT {
     
     var alert: UIAlertController?
     
-    fileprivate init(){}
+    private init(){}
     
-    fileprivate init(title: String?, message: String?, preferredStyle: UIAlertController.Style) {
+    private init(title: String?, message: String?, preferredStyle: UIAlertController.Style) {
         self.alert = UIAlertController(title: title,
                                        message: message,
                                        preferredStyle: preferredStyle)

--- a/ALRT/ALRT.swift
+++ b/ALRT/ALRT.swift
@@ -3,141 +3,147 @@ import UIKit
 /// Responsible for creating and managing an ALRT object.
 
 public class ALRT {
-    
     /**
      Result indicating whether the alert is displayed or not.
-     
+
      - success: The alert is displayed.
      - failure: The alert is not displayed due to an ALRTError.
      */
-    
+
     public enum Result {
         case success
         case failure(ALRTError)
     }
-    
+
     /**
      ALRTError enums.
-     
+
      - alertControllerNil: The alert controller is nil.
      - popoverNotSet: An attempt to show .ActionSheet type alert controller failed because the popover presentation controller has not been set up.
      */
-    
+
     public enum ALRTError: Error {
         case alertControllerNil
         case popoverNotSet
         case sourceViewControllerNil
     }
-    
+
     var alert: UIAlertController?
-    
-    private init(){}
-    
-    private init(title: String?, message: String?, preferredStyle: UIAlertController.Style) {
-        self.alert = UIAlertController(title: title,
-                                       message: message,
-                                       preferredStyle: preferredStyle)
+
+    private init() {}
+
+    private init(
+        title: String?,
+        message: String?,
+        preferredStyle: UIAlertController.Style
+    ) {
+        alert = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: preferredStyle
+        )
     }
-    
+
     // MARK: Creating an ALRT
-    
+
     /**
      Creates an ALRT object.
-     
+
      - parameter style:   UIAlertControllerStyle constants indicating the type of alert to display.
      - parameter title:   The title of the alert.
      - parameter message: The message of the alert.
-     
+
      - returns: ALRT
      */
-    
-    public class func create(_ style: UIAlertController.Style,
-                           title: String? = nil,
-                           message: String? = nil) -> ALRT {
-        
+
+    public class func create(
+        _ style: UIAlertController.Style,
+        title: String? = nil,
+        message: String? = nil
+    ) -> ALRT {
         return ALRT(title: title, message: message, preferredStyle: style)
     }
-    
+
     // MARK: Fetching the Alert
-    
+
     /**
      Fetches the ALRT object's alert controller.
-     
+
      - parameter handler: A block for fetching the alert controller. This block has no return value and takes the alert controller.
-     
+
      - returns: Self
      */
-    
+
     @discardableResult
-    public func fetch(_ handler: ((_ alertController: UIAlertController?) -> Void)) -> Self {
-        handler(self.alert)
+    public func fetch(_ handler: (_ alertController: UIAlertController?) -> Void) -> Self {
+        handler(alert)
         return self
     }
-    
+
     // MARK: Configuring Text Fields
-    
+
     /**
      Adds a text field to an alert.
-     
+
      - parameter configurationHandler: A block for configuring the text field prior to displaying the alert. This block has no return value and takes a single parameter corresponding to the text field object. Use that parameter to change the text field properties.
-     
+
      - returns: Self
      */
-    
+
     @discardableResult
     public func addTextField(_ configurationHandler: ((_ textField: UITextField) -> Void)?) -> Self {
         guard alert?.preferredStyle == .alert else {
             return self
         }
-        
-        alert?.addTextField {
-            textField in
+
+        alert?.addTextField { textField in
             if let configurationHandler = configurationHandler {
                 configurationHandler(textField)
             }
         }
-        
+
         return self
     }
-    
+
     // MARK: Configuring Customizable User Actions
-    
+
     /**
      Attaches an action object to the alert or action sheet.
-     
+
      - parameter title:     The title of the action’s button.
      - parameter style:     The style that is applied to the action’s button. The default value is .Default.
      - parameter preferred: The preferred action for the user to take from an alert(iOS 9 or later). The default value is false.
      - parameter handler:   A block to execute when the user selects the action. This block has no return value and take the selected action object and the text fields added to the alert controller if any. The default value is nil.
-     
+
      - returns: Self
      */
-    
+
     @discardableResult
-    public func addAction(_ title: String?,
-                        style: UIAlertAction.Style = .default,
-                        preferred: Bool = false,
-                        handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil) -> Self {
-        
+    public func addAction(
+        _ title: String?,
+        style: UIAlertAction.Style = .default,
+        preferred: Bool = false,
+        handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil
+    ) -> Self {
         let action = UIAlertAction(title: title, style: style) { action in
             handler?(action, self.alert?.preferredStyle == .alert ? self.alert?.textFields : nil)
             self.alert = nil
         }
-        
+
         alert?.addAction(action)
-        
+
         if preferred {
             alert?.preferredAction = action
         }
-        
+
         return self
     }
-    
+
     // MARK: Configuring Pre-defined User Actions
-    
+
     /**
      Attaches an action object to the alert or action sheet. The default title is "OK".
-     
+
      - parameter title:     The title of the action’s button. The default value is "OK".
      - parameter style:     The style that is applied to the action’s button. The default value is .Default.
      - parameter preferred: The preferred action for the user to take from an alert(iOS 9 or later). The default value is false.
@@ -145,101 +151,102 @@ public class ALRT {
 
      - returns: Self
      */
-    
+
     @discardableResult
-    public func addOK(_ title: String = "OK",
-                    style: UIAlertAction.Style = .default,
-                    preferred: Bool = false,
-                    handler:((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil) -> Self {
-        
+    public func addOK(
+        _ title: String = "OK",
+        style: UIAlertAction.Style = .default,
+        preferred: Bool = false,
+        handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil
+    ) -> Self {
         return addAction(title, style: style, preferred: preferred, handler: handler)
     }
-    
+
     /**
      Attaches an action object to the alert or action sheet. The default title is "Cancel".
-     
+
      - parameter title:     The title of the action’s button. The default value is "Cancel".
      - parameter style:     The style that is applied to the action’s button. The default value is .Cancel.
      - parameter preferred: The preferred action for the user to take from an alert(iOS 9 or later). The default value is false.
      - parameter handler:   A block to execute when the user selects the action. This block has no return value and take the selected action object and the text fields added to the alert controller if any. The default value is nil.
-     
+
      - returns: Self
      */
-    
+
     @discardableResult
-    public func addCancel(_ title: String = "Cancel",
-                        style: UIAlertAction.Style = .cancel,
-                        preferred: Bool = false,
-                        handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil) -> Self {
-        
+    public func addCancel(
+        _ title: String = "Cancel",
+        style: UIAlertAction.Style = .cancel,
+        preferred: Bool = false,
+        handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil
+    ) -> Self {
         return addAction(title, style: style, preferred: preferred, handler: handler)
     }
-    
+
     /**
      Attaches an action object to the alert or action sheet. The default style is .Destructive.
-     
+
      - parameter title:     The title of the action’s button.
      - parameter style:     The style that is applied to the action’s button. The default value is .Destructive.
      - parameter preferred: The preferred action for the user to take from an alert(iOS 9 or later). The default value is false.
      - parameter handler:   A block to execute when the user selects the action. This block has no return value and take the selected action object and the text fields added to the alert controller if any. The default value is nil.
-     
+
      - returns: Self
      */
-    
+
     @discardableResult
-    public func addDestructive(_ title: String?,
-                             style: UIAlertAction.Style = .destructive,
-                             preferred: Bool = false,
-                             handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil)-> Self {
-        
+    public func addDestructive(
+        _ title: String?,
+        style: UIAlertAction.Style = .destructive,
+        preferred: Bool = false,
+        handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil
+    ) -> Self {
         return addAction(title, style: style, preferred: preferred, handler: handler)
     }
-    
+
     // MARK: Configuring the Popover Presentation
-    
+
     /** Configures the alert controller's popover presentation controller.
-     
-     
+
      - parameter configurationHandler: A block for configuring the popover presentation controller. This block has no return value and take the alert controller's popover presentation controller. If the alert controller's style is .ActionSheet and the device is iPad, this configuration is necessary.
-     
+
      - returns: Self
      */
-    
+
     @discardableResult
-    public func configurePopoverPresentation(_ configurationHandler:((_ popover: UIPopoverPresentationController?) -> Void)? = nil) -> Self {
-        
+    public func configurePopoverPresentation(_ configurationHandler: ((_ popover: UIPopoverPresentationController?) -> Void)? = nil) -> Self {
         configurationHandler?(alert?.popoverPresentationController)
-        
         return self
     }
-    
+
     // MARK: Showing the Alert
-    
+
     /**
      Displays the alert or action sheet.
-     
+
      - parameter viewControllerToPresent: The view controller to display the alert from. The default value is nil. If the parameter is not given, the key window's root view controller will present the alert.
      - parameter animated:       Pass true to animate the presentation; otherwise, pass false. The default value is true.
      - parameter completion:     The block to execute after the presentation finishes. This block has no return value and takes an Result parameter. The default value is nil.
      */
-    
-    public func show(_ viewControllerToPresent: UIViewController? = nil,
-                   animated: Bool = true,
-                   completion: @escaping ((ALRT.Result) -> Void) = { _ in } ) {
-        
+
+    public func show(
+        _ viewControllerToPresent: UIViewController? = nil,
+        animated: Bool = true,
+        completion: @escaping ((ALRT.Result) -> Void) = { _ in }
+    ) {
         guard let alert = self.alert else {
             completion(.failure(.alertControllerNil))
             return
         }
-        
-        if UIDevice.current.userInterfaceIdiom == .pad &&
-            alert.preferredStyle == .actionSheet &&
-            alert.popoverPresentationController?.sourceView == nil &&
+
+        if UIDevice.current.userInterfaceIdiom == .pad,
+            alert.preferredStyle == .actionSheet,
+            alert.popoverPresentationController?.sourceView == nil,
             alert.popoverPresentationController?.barButtonItem == nil {
             completion(.failure(.popoverNotSet))
             return
         }
-        
+
         let sourceViewController: UIViewController? = {
             let viewController = viewControllerToPresent ?? UIApplication.shared.topMostViewController()
             if let navigationController = viewController as? UINavigationController {
@@ -256,24 +263,22 @@ public class ALRT {
             completion(.failure(.sourceViewControllerNil))
         }
     }
-    
 }
 
 private extension UIViewController {
     func topMostViewController() -> UIViewController {
-        
-        if let presented = self.presentedViewController {
+        if let presented = presentedViewController {
             return presented.topMostViewController()
         }
-        
+
         if let navigation = self as? UINavigationController {
             return navigation.visibleViewController?.topMostViewController() ?? navigation
         }
-        
+
         if let tab = self as? UITabBarController {
             return tab.selectedViewController?.topMostViewController() ?? tab
         }
-        
+
         return self
     }
 }

--- a/ALRT/ALRT.swift
+++ b/ALRT/ALRT.swift
@@ -28,7 +28,7 @@ public class ALRT {
         case sourceViewControllerNil
     }
 
-    var alert: UIAlertController?
+    var alertController: UIAlertController?
 
     private init() {}
 
@@ -37,7 +37,7 @@ public class ALRT {
         message: String?,
         preferredStyle: UIAlertController.Style
     ) {
-        alert = UIAlertController(
+        alertController = UIAlertController(
             title: title,
             message: message,
             preferredStyle: preferredStyle
@@ -76,7 +76,7 @@ public class ALRT {
 
     @discardableResult
     public func fetch(_ handler: (_ alertController: UIAlertController?) -> Void) -> Self {
-        handler(alert)
+        handler(alertController)
         return self
     }
 
@@ -92,11 +92,11 @@ public class ALRT {
 
     @discardableResult
     public func addTextField(_ configurationHandler: ((_ textField: UITextField) -> Void)?) -> Self {
-        guard alert?.preferredStyle == .alert else {
+        guard alertController?.preferredStyle == .alert else {
             return self
         }
 
-        alert?.addTextField { textField in
+        alertController?.addTextField { textField in
             if let configurationHandler = configurationHandler {
                 configurationHandler(textField)
             }
@@ -126,14 +126,14 @@ public class ALRT {
         handler: ((_ action: UIAlertAction, _ textFields: [UITextField]?) -> Void)? = nil
     ) -> Self {
         let action = UIAlertAction(title: title, style: style) { action in
-            handler?(action, self.alert?.preferredStyle == .alert ? self.alert?.textFields : nil)
-            self.alert = nil
+            handler?(action, self.alertController?.preferredStyle == .alert ? self.alertController?.textFields : nil)
+            self.alertController = nil
         }
 
-        alert?.addAction(action)
+        alertController?.addAction(action)
 
         if preferred {
-            alert?.preferredAction = action
+            alertController?.preferredAction = action
         }
 
         return self
@@ -215,7 +215,7 @@ public class ALRT {
 
     @discardableResult
     public func configurePopoverPresentation(_ configurationHandler: ((_ popover: UIPopoverPresentationController?) -> Void)? = nil) -> Self {
-        configurationHandler?(alert?.popoverPresentationController)
+        configurationHandler?(alertController?.popoverPresentationController)
         return self
     }
 
@@ -234,7 +234,7 @@ public class ALRT {
         animated: Bool = true,
         completion: @escaping ((ALRT.Result) -> Void) = { _ in }
     ) {
-        guard let alert = self.alert else {
+        guard let alert = self.alertController else {
             completion(.failure(.alertControllerNil))
             return
         }

--- a/ALRT/Info.plist
+++ b/ALRT/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.4</string>
+	<string>1.3.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Demo/DemoTests/DemoTests.swift
+++ b/Demo/DemoTests/DemoTests.swift
@@ -101,7 +101,44 @@ class DemoTests: XCTestCase {
 
         self.waitForExpectations(timeout: 3.0, handler: nil)
     }
-    
+
+    func testDefaultConfiguration() {
+        defer {
+            ALRT.defaultConfiguration = nil
+        }
+
+        let expectation = self.expectation(description: "Setting defaultConfiguration should change tintColor, okTitle, cancelTitle")
+
+        let expectedTintColor = UIColor.red
+        let expectedOKTitle = "AAA"
+        let expectedCancelTitle = "BBB"
+
+        ALRT.defaultConfiguration = .init(
+            tintColor: expectedTintColor,
+            okTitle: expectedOKTitle,
+            cancelTitle: expectedCancelTitle
+        )
+
+        ALRT.create(.alert)
+            .addOK()
+            .addCancel()
+            .fetch { alert in
+                let actualTintColor = alert?.view.tintColor
+                XCTAssertEqual(actualTintColor, expectedTintColor)
+
+                let actualOKTitle = alert?.actions.first?.title
+                XCTAssertEqual(actualOKTitle, expectedOKTitle)
+
+                let actualCancelTitle = alert?.actions.last?.title
+                XCTAssertEqual(actualCancelTitle, expectedCancelTitle)
+
+                expectation.fulfill()
+            }
+            .show()
+
+        self.waitForExpectations(timeout: 3.0, handler: nil)
+    }
+
     func inspect(_ result: ALRT.Result) {
         if case .success = result {
             XCTAssertTrue(true)

--- a/README.md
+++ b/README.md
@@ -26,19 +26,19 @@ ALRT.create(.alert, title: "Alert?").addOK().addCancel().show()
 * Returns `Result` whether an alert is successfully displayed. In other words, [Unit Testable](https://github.com/mshrwtnb/ALRT/blob/master/Demo/DemoTests/DemoTests.swift).
 
 ## Requirements
-* Xcode 10.2
+* Xcode 10.2+
 * Swift 5.0
 * iOS 9.0+
 
 ## Installation
 ### Carthage
 ```
-github "mshrwtnb/ALRT" ~> 1.3.4
+github "mshrwtnb/ALRT" ~> 1.3.5
 ```
 ### Cocoapods
 ```
 pod repo update
-pod 'ALRT', '~> 1.3.4'
+pod 'ALRT', '~> 1.3.5'
 ```
 
 ## Usage
@@ -155,6 +155,17 @@ Although ALRT can present an alert anywhere, you might want to specify a source 
 ALRT.create(.alert, title: "Source?")
     .addOK()
     .show(self) // self = source view controller
+```
+
+### Default Configuration
+Set default tintColor and titles for OK and Cancel buttons.
+
+```swift
+ALRT.defaultConfiguration = .init(
+    tintColor: UIColor.blue,
+    okTitle: "OK👍",
+    cancelTitle: "Cancel👎"
+)
 ```
 
 ## License


### PR DESCRIPTION
This PR enables ALRT to use `defaultConfiguration`. 
By setting `defaultConfiguration`, ALRT can ...
1. Show an UIAlertController with user-defined tint color
2. Show `OK` and `Cancel` buttons with user-defined titles

See https://github.com/mshrwtnb/ALRT/pull/15/files#diff-f748f6c5192632893abcb48efd218a3fR105-R140 to understand how to use `defaultConfiguration` and its expected behavior.